### PR TITLE
[qtconnectivity] Stop device discovery session before retrieving serv…

### DIFF
--- a/src/bluetooth/qbluetoothdevicediscoveryagent_bluez.cpp
+++ b/src/bluetooth/qbluetoothdevicediscoveryagent_bluez.cpp
@@ -126,6 +126,7 @@ void QBluetoothDeviceDiscoveryAgentPrivate::start()
     }
 
     QDBusPendingReply<> discoveryReply = adapter->StartDiscovery();
+    discoveryReply.waitForFinished();
     if (discoveryReply.isError()) {
         delete adapter;
         adapter = 0;

--- a/src/bluetooth/qbluetoothdevicediscoveryagent_bluez.cpp
+++ b/src/bluetooth/qbluetoothdevicediscoveryagent_bluez.cpp
@@ -198,18 +198,24 @@ void QBluetoothDeviceDiscoveryAgentPrivate::_q_propertyChanged(const QString &na
 
     if (name == QLatin1String("Discovering") && !value.variant().toBool()) {
         Q_Q(QBluetoothDeviceDiscoveryAgent);
-        adapter->deleteLater();
-        adapter = 0;
         if(pendingCancel && !pendingStart){
+            adapter->deleteLater();
+            adapter = 0;
             emit q->canceled();
             pendingCancel = false;
         }
         else if(pendingStart){
+            adapter->deleteLater();
+            adapter = 0;
             pendingStart = false;
             pendingCancel = false;
             start();
         }
         else {
+            QDBusPendingReply<> reply = adapter->StopDiscovery();
+            reply.waitForFinished();
+            adapter->deleteLater();
+            adapter = 0;
             emit q->finished();
         }
     }


### PR DESCRIPTION
…ice records. Fixes MER#1230

Each org.bluez.Adapter.StartDiscovery should be paired with a
corresponding StopDiscovery; it is not enough to merely observe that
an adapter's Discovering property momentarily changes from true to
false.
